### PR TITLE
Corrected Docker Hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker container VLC server for video stream.
 VLC media player version 3.0.9.2 Vetinari (revision 3.0.9.2-0-gd4c1aefe4d)
 
 This VLC image can be found at:
-* [Docker Hub](https://hub.docker.com/repository/docker/lroktu/vlc-server)
+* [Docker Hub](https://hub.docker.com/r/lroktu/vlc-server)
 
 # Usage
 


### PR DESCRIPTION
This was pointing at the internal project page. Corrected to the public project page.